### PR TITLE
Add new endpoint to allow automation tests to cancel a visit via the visit scheduler

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsprisonvisitstestinghelperapi/client/VisitSchedulerClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsprisonvisitstestinghelperapi/client/VisitSchedulerClient.kt
@@ -7,6 +7,8 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.BodyInserters
 import org.springframework.web.reactive.function.client.WebClient
+import uk.gov.justice.digital.hmpps.hmppsprisonvisitstestinghelperapi.dto.CancelVisitDto
+import uk.gov.justice.digital.hmpps.hmppsprisonvisitstestinghelperapi.dto.OutcomeDto
 import uk.gov.justice.digital.hmpps.hmppsprisonvisitstestinghelperapi.dto.PrisonExcludeDateDto
 import java.time.Duration
 import java.time.LocalDate
@@ -45,5 +47,24 @@ class VisitSchedulerClient(
       .block(apiTimeout)
 
     LOG.info("Finished calling remove exclude date for prison - $prisonCode, excluded date - $excludeDate")
+  }
+
+  fun cancelVisitByReference(reference: String) {
+    LOG.info("Calling the visit scheduler to cancel a visit with reference - $reference")
+
+    val body = CancelVisitDto(
+      OutcomeDto("CANCELLED"),
+      "testing-helper-api",
+      "NOT_KNOWN",
+    )
+    webClient.put()
+      .uri("/visits/$reference/cancel")
+      .body(BodyInserters.fromValue(body))
+      .retrieve()
+      .toBodilessEntity()
+      .doOnError { e -> LOG.error("Could not cancel visit :", e) }
+      .block(apiTimeout)
+
+    LOG.info("Finished calling the visit scheduler to cancel a visit with reference - $reference")
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsprisonvisitstestinghelperapi/controller/TestingVisitSchedulerHelperController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsprisonvisitstestinghelperapi/controller/TestingVisitSchedulerHelperController.kt
@@ -1,0 +1,47 @@
+package uk.gov.justice.digital.hmpps.hmppsprisonvisitstestinghelperapi.controller
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.MediaType
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.hmppsprisonvisitstestinghelperapi.service.VisitSchedulerService
+
+const val CANCEL_VISIT_URI: String = "$BASE_VISIT_URI/{reference}/cancel"
+
+@RestController
+class TestingVisitSchedulerHelperController {
+
+  @Autowired
+  lateinit var visitSchedulerService: VisitSchedulerService
+
+  @PreAuthorize("hasAnyRole('TEST_VISIT_SCHEDULER')")
+  @PostMapping(
+    CANCEL_VISIT_URI,
+    produces = [MediaType.TEXT_PLAIN_VALUE],
+  )
+  @Operation(
+    summary = "Cancel a visit via the visit-scheduler",
+    responses = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Visit has been cancelled",
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "Count not find visit for given reference",
+      ),
+    ],
+  )
+  fun cancelVisit(
+    @Schema(description = "reference", example = "v9-d7-ed-7u", required = true)
+    @PathVariable
+    reference: String,
+  ) {
+    visitSchedulerService.cancelVisitByReference(reference)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsprisonvisitstestinghelperapi/dto/CancelVisitDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsprisonvisitstestinghelperapi/dto/CancelVisitDto.kt
@@ -1,0 +1,20 @@
+package uk.gov.justice.digital.hmpps.hmppsprisonvisitstestinghelperapi.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.Valid
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+
+data class CancelVisitDto(
+  @Schema(description = "Outcome - status and text", required = true)
+  @field:Valid
+  val cancelOutcome: OutcomeDto,
+
+  @Schema(description = "Username for user who actioned this request", required = true)
+  @field:NotBlank
+  val actionedBy: String,
+
+  @Schema(description = "application method", required = true)
+  @field:NotNull
+  val applicationMethodType: String,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsprisonvisitstestinghelperapi/dto/OutcomeDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsprisonvisitstestinghelperapi/dto/OutcomeDto.kt
@@ -1,0 +1,13 @@
+package uk.gov.justice.digital.hmpps.hmppsprisonvisitstestinghelperapi.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotNull
+
+@Schema(description = "Visit Outcome")
+class OutcomeDto(
+  @Schema(description = "Outcome Status", example = "CANCELLED", required = true)
+  @field:NotNull
+  val outcomeStatus: String,
+  @Schema(description = "Outcome text", example = "Because he got covid", required = false)
+  val text: String? = null,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsprisonvisitstestinghelperapi/service/VisitSchedulerService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsprisonvisitstestinghelperapi/service/VisitSchedulerService.kt
@@ -1,0 +1,19 @@
+package uk.gov.justice.digital.hmpps.hmppsprisonvisitstestinghelperapi.service
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.hmppsprisonvisitstestinghelperapi.client.VisitSchedulerClient
+
+@Service
+class VisitSchedulerService(
+  private val visitSchedulerClient: VisitSchedulerClient,
+) {
+  private val logger: Logger = LoggerFactory.getLogger(this::class.java)
+
+  fun cancelVisitByReference(reference: String) {
+    logger.debug("cancelVisitByReference called with reference - {}", reference)
+
+    visitSchedulerClient.cancelVisitByReference(reference)
+  }
+}


### PR DESCRIPTION
## What does this PR do ?
Reason for this endpoint is to help with visit-order (VO) balance being exhausted during automation testing. Instead of cancelling via the Db directly, we call the visit scheduler to do it and this will mean the VO for the visit is refunded.