### PR TITLE
New orb 9.2.0 includes a fix for docker layer caching error we've been experiencing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  hmpps: ministryofjustice/hmpps@8
+  hmpps: ministryofjustice/hmpps@9.2.0
 
 parameters:
   alerts-slack-channel:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 
 This is a Spring Boot application, written in Kotlin. It is a testing helper API for automated tests. Used by [Visits UI Tests](https://github.com/ministryofjustice/hmpps-vsip-ui-tests).
 
-
 ## Building
 
 To build the project (without tests):


### PR DESCRIPTION
Update to that orb to test if the error is fixed.