### PR TITLE
Add alert severity

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -17,3 +17,8 @@ generic-service:
   scheduledDowntime:
     enabled: true
 
+# CloudPlatform AlertManager receiver to route prometheus alerts to slack
+# See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts
+generic-prometheus-alerts:
+  alertSeverity: visits-alerts-nonprod
+  businessHoursOnly: true

--- a/helm_deploy/values-staging.yaml
+++ b/helm_deploy/values-staging.yaml
@@ -15,3 +15,9 @@ generic-service:
 
   scheduledDowntime:
     enabled: true
+
+# CloudPlatform AlertManager receiver to route prometheus alerts to slack
+# See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts
+generic-prometheus-alerts:
+  alertSeverity: visits-alerts-nonprod
+  businessHoursOnly: true


### PR DESCRIPTION
The below error is shown after the helm upgrade - and deploy fails. Hence adding this fix.

Error: UPGRADE FAILED: execution error at (hmpps-prison-visits-testing-helper-api/charts/generic-prometheus-alerts/templates/ingress-alerts.yaml:30:16): A value for alertSeverity must be set