### PR TITLE
fix clear visits endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsprisonvisitstestinghelperapi/repository/VisitRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsprisonvisitstestinghelperapi/repository/VisitRepository.kt
@@ -116,6 +116,13 @@ interface VisitRepository : JpaRepository<NotUsedVisitEntity, Long> {
 
   @Modifying
   @Query(
+    "delete from visit_notify_history where event_audit_id IN (select id from event_audit where booking_reference = :bookingReference)",
+    nativeQuery = true,
+  )
+  fun deleteVisitNotifyHistoryByBookingReference(bookingReference: String): Int
+
+  @Modifying
+  @Query(
     "insert into visit_notification_event(booking_reference, type, reference, visit_id) values (:bookingReference, :notificationType, :reference, :visitId)",
     nativeQuery = true,
   )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsprisonvisitstestinghelperapi/service/VisitService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsprisonvisitstestinghelperapi/service/VisitService.kt
@@ -108,6 +108,7 @@ class VisitService(
       visitRepository.deleteVisitNotes(it)
       visitRepository.deleteVisitContact(it)
       visitRepository.deleteVisitLegacy(it)
+      visitRepository.deleteVisitNotifyHistoryByBookingReference(bookingReference)
       visitRepository.deleteVisitNotificationEventsByBookingReference(bookingReference)
       visitRepository.deleteVisit(it)
 


### PR DESCRIPTION
## What does this PR do?
Removes visit_notify_history entries in the clear visits endpoint, to avoid triggering a foreign key constraint exception and keeping leftover data when not wanted.